### PR TITLE
Refactor telemetry sender.ts to move filtering code into separate module

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/telemetry/filters.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/filters.ts
@@ -1,0 +1,146 @@
+import {
+	TelemetryEvent
+} from './types';
+
+// For the Allowlist definition.
+
+interface AllowlistFields {
+	[key: string]: boolean | AllowlistFields;
+}
+
+// Allow list process fields within events.  This includes "process" and "Target.process".'
+const allowlistProcessFields: AllowlistFields = {
+	args: true,
+	name: true,
+	executable: true,
+	command_line: true,
+	hash: true,
+	pid: true,
+	pe: {
+		original_file_name: true,
+	},
+	uptime: true,
+	Ext: {
+		architecture: true,
+		code_signature: true,
+		dll: true,
+		malware_signature: true,
+		token: {
+			integrity_level_name: true,
+		},
+	},
+	thread: true,
+	working_directory: true,
+};
+
+// Allow list for event-related fields, which can also be nested under events[]
+const allowlistBaseEventFields: AllowlistFields = {
+	dll: {
+		name: true,
+		path: true,
+		code_signature: true,
+		malware_signature: true,
+		pe: {
+			original_file_name: true,
+		},
+	},
+	event: true,
+	file: {
+		extension: true,
+		name: true,
+		path: true,
+		size: true,
+		created: true,
+		accessed: true,
+		mtime: true,
+		directory: true,
+		hash: true,
+		Ext: {
+			code_signature: true,
+			header_data: true,
+			malware_classification: true,
+			malware_signature: true,
+			quarantine_result: true,
+			quarantine_message: true,
+		},
+	},
+	process: {
+		parent: allowlistProcessFields,
+		...allowlistProcessFields,
+	},
+	network: {
+		direction: true,
+	},
+	registry: {
+		data: {
+			strings: true,
+		},
+		hive: true,
+		key: true,
+		path: true,
+		value: true,
+	},
+	Target: {
+		process: {
+			parent: allowlistProcessFields,
+			...allowlistProcessFields,
+		},
+	},
+	user: {
+		id: true,
+	},
+};
+
+// Allow list for the data we include in the events. True means that it is deep-cloned
+// blindly. Object contents means that we only copy the fields that appear explicitly in
+// the sub-object.
+export const AllowlistAlertEventFields: AllowlistFields = {
+	'@timestamp': true,
+	agent: true,
+	Endpoint: true,
+	/* eslint-disable @typescript-eslint/naming-convention */
+	Memory_protection: true,
+	Ransomware: true,
+	data_stream: true,
+	ecs: true,
+	elastic: true,
+	// behavioral protection re-nests some field sets under events.*
+	events: allowlistBaseEventFields,
+	rule: {
+		id: true,
+		name: true,
+		ruleset: true,
+		version: true,
+	},
+	host: {
+		os: true,
+	},
+	...allowlistBaseEventFields,
+};
+
+export function copyAllowlistedFields(
+	allowlist: AllowlistFields,
+	event: TelemetryEvent
+): TelemetryEvent {
+	return Object.entries(allowlist).reduce<TelemetryEvent>((newEvent, [allowKey, allowValue]) => {
+		const eventValue = event[allowKey];
+		if (eventValue !== null && eventValue !== undefined) {
+			if (allowValue === true) {
+				return { ...newEvent, [allowKey]: eventValue };
+			} else if (typeof allowValue === 'object' && Array.isArray(eventValue)) {
+				const subValues = eventValue.filter((v) => typeof v === 'object');
+				return {
+					...newEvent,
+					[allowKey]: subValues.map((v) => copyAllowlistedFields(allowValue, v as TelemetryEvent)),
+				};
+			} else if (typeof allowValue === 'object' && typeof eventValue === 'object') {
+				const values = copyAllowlistedFields(allowValue, eventValue as TelemetryEvent);
+				return {
+					...newEvent,
+					...(Object.keys(values).length > 0 ? { [allowKey]: values } : {}),
+				};
+			}
+		}
+		return newEvent;
+	}, {});
+}

--- a/x-pack/plugins/security_solution/server/lib/telemetry/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/types.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+type BaseSearchTypes = string | number | boolean | object;
+export type SearchTypes = BaseSearchTypes | BaseSearchTypes[] | undefined;
+
 // EP Policy Response
 
 export interface EndpointPolicyResponseAggregation {
@@ -137,4 +140,36 @@ interface EndpointMetricOS {
   version: string;
   platform: string;
   full: string;
+}
+
+export interface ESLicense {
+  status: string;
+  uid: string;
+  type: string;
+  issue_date?: string;
+  issue_date_in_millis?: number;
+  expiry_date?: string;
+  expirty_date_in_millis?: number;
+  max_nodes?: number;
+  issued_to?: string;
+  issuer?: string;
+  start_date_in_millis?: number;
+}
+
+export interface TelemetryEvent {
+  [key: string]: SearchTypes;
+  '@timestamp'?: string;
+  data_stream?: {
+    [key: string]: SearchTypes;
+    dataset?: string;
+  };
+  cluster_name?: string;
+  cluster_uuid?: string;
+  file?: {
+    [key: string]: SearchTypes;
+    Ext?: {
+      [key: string]: SearchTypes;
+    };
+  };
+  license?: ESLicense;
 }


### PR DESCRIPTION
## Summary

This PR does the following:
1) Lifts some common types from `sender.ts` into `types.ts`
2) Lifts some filter-specific types and functions into a `filters.ts` module.

In order to help refactor the Kibana Security app telemetry, we need to modularize the `sender.ts` code, accounting for the growth in
1) Filtering
2) Receiver logic (Querying ES to receive telemetry events)

@pjhampton, would love your comments here even if you think this is off-base 😄 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
